### PR TITLE
feat: add continuous integration workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -23,30 +23,36 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      tf-files: ${{ steps.filter-tf.outputs.tf_files }}
+      tf-files: ${{ steps.filter.outputs.tf_files }}
+      yaml-files: ${{ steps.filter.outputs.yaml_files }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
-        id: filter-tf
+      - uses: dorny/paths-filter@v3.0.2 # Predicate quantifier is new in v3.0.2
+        id: filter
         with:
           list-files: shell
+          predicate-quantifier: "every"
           filters: |
             tf:
               - added|modified: '**/*.tf'
+            yaml:
+              - added|modified: '**/*.yaml'
+              - '!**/secrets.yaml'
 
-  # Run the format check for changed Terraform files
+  # Run the format check for changed Terraform and YAML files
   format-checks:
     name: Format Checks
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.tf-files != '' }}
+    if: ${{ needs.changes.outputs.tf-files != '' || needs.changes.outputs.yaml-files != '' }}
     steps:
       - uses: actions/checkout@v5
       - uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check OpenTofu formatting
+        if: ${{ needs.changes.outputs.tf-files != '' }}
         run: |
           echo "## OpenTofu Format Check" >> $GITHUB_STEP_SUMMARY
           if nix develop --command tofu fmt -check ${{ needs.changes.outputs.tf-files }} > tofu_output.txt 2>&1; then
@@ -54,6 +60,17 @@ jobs:
           else
             cat tofu_output.txt >> $GITHUB_STEP_SUMMARY
             echo "❌ Terraform formatting issues found" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+      - name: Check YAML formatting
+        if: ${{ needs.changes.outputs.yaml-files != '' }}
+        run: |
+          echo "## YAML Format Check" >> $GITHUB_STEP_SUMMARY
+          if nix develop --command yamllint --config-file .yaml-rules.yaml ${{ needs.changes.outputs.yaml-files }} > yaml_output.txt 2>&1; then
+            echo "✅ All YAML files properly formatted" >> $GITHUB_STEP_SUMMARY
+          else
+            cat yaml_output.txt >> $GITHUB_STEP_SUMMARY
+            echo "❌ YAML formatting issues found" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,74 @@
+name: Continuous Integration
+
+# This is used to trigger the CI job
+# The job will run when a pull request is created against the main branch
+on:
+  pull_request:
+    branches:
+      - main
+
+# This is used to scope the permissions for the CI job
+permissions:
+  contents: read
+  pull-requests: read
+
+# This is used to prevent multiple CI jobs from running concurrently
+# If a new commit is pushed, the previous job will be cancelled and a new one will be started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Create matrixes for the various CI targets
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tf-files: ${{ steps.filter-tf.outputs.tf_files }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter-tf
+        with:
+          list-files: shell
+          filters: |
+            tf:
+              - added|modified: '**/*.tf'
+
+  # Run the format check for changed Terraform files
+  format-checks:
+    name: Format Checks
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.tf-files != '' }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check OpenTofu formatting
+        run: |
+          echo "## OpenTofu Format Check" >> $GITHUB_STEP_SUMMARY
+          if nix develop --command tofu fmt -check ${{ needs.changes.outputs.tf-files }} > tofu_output.txt 2>&1; then
+            echo "✅ All Terraform files properly formatted" >> $GITHUB_STEP_SUMMARY
+          else
+            cat tofu_output.txt >> $GITHUB_STEP_SUMMARY
+            echo "❌ Terraform formatting issues found" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+  # Aggregate the results of the checks and set the CI status
+  # This is used to determine the overall status of the CI pipeline
+  # Used in branch protection rules to prevent merging if the CI fails
+  ci-status:
+    name: CI Status
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - format-checks
+    if: always()
+    steps:
+      - if: ${{ !cancelled() && !(contains(needs.*.result, 'failure')) }}
+        run: echo "CI passed"
+      - if: ${{ !cancelled() && contains(needs.*.result, 'failure') }}
+        run: echo "CI failed"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,7 @@
 {
   "recommendations": [
-    "opentofu.vscode-opentofu"
+    "opentofu.vscode-opentofu",
+    "github.vscode-github-actions",
+    "redhat.vscode-yaml"
   ]
 }

--- a/.yaml-rules.yaml
+++ b/.yaml-rules.yaml
@@ -1,0 +1,4 @@
+rules:
+  document-start: disable
+  trailing-spaces:
+    level: error

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,8 @@
             sops
             age
             just
+            # Tooling
+            yamllint
           ];
         };
       });

--- a/project/github-repository.tf
+++ b/project/github-repository.tf
@@ -1,9 +1,9 @@
 resource "github_repository" "github_repository" {
-  name         = "sandefjord-game-platform"
-  description  = "Kodehode Sandefjord Game Platform"
+  name        = "sandefjord-game-platform"
+  description = "Kodehode Sandefjord Game Platform"
 
   # Settings
-  visibility   = "public"
+  visibility         = "public"
   archive_on_destroy = true
 
   # Features


### PR DESCRIPTION
Implement a new GitHub Actions workflow for continuous integration that includes:
- A job to check for changes in infrastructure-as-code files
- A format check for OpenTofu configurations
- Status reporting for CI results

Additionally, update the VSCode extensions recommendations to include GitHub Actions and YAML support.