### PR TITLE
fix: correct CI status context name in branch protection policy

### DIFF
--- a/project/github-continuous-integration-policies.tf
+++ b/project/github-continuous-integration-policies.tf
@@ -19,7 +19,7 @@ resource "github_branch_protection" "main" {
     strict = true
     # We are only asserting against the aggregate CI status currently
     contexts = [
-      "ci-status"
+      "CI Status"
     ]
   }
 


### PR DESCRIPTION
- Update the context name from "ci-status" to "CI Status" for consistency in the GitHub branch protection configuration.